### PR TITLE
feat: Implement ghost text erosion effect

### DIFF
--- a/src/TypeWriter.css
+++ b/src/TypeWriter.css
@@ -936,3 +936,42 @@
 .ghost-char-pulse {
   animation: pulseSizeChar 1.0s ease-out forwards; /* Duration for pulse */
 }
+
+@keyframes wordErodeFadeOut {
+  from {
+    opacity: 1;
+    transform: scale(1);
+    filter: blur(0);
+  }
+  to {
+    opacity: 0;
+    transform: scale(0.8);
+    filter: blur(2px);
+  }
+}
+
+.word-eroding-fadeout {
+  animation: wordErodeFadeOut 1.5s ease-out forwards;
+  /* Important to keep words from re-appearing if they are re-rendered before removal */
+  opacity: 0; 
+  transform: scale(0.8);
+  filter: blur(2px);
+}
+
+@keyframes wordErodeSink {
+  from {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(10px) scale(0.9);
+  }
+}
+
+.word-eroding-sink {
+  animation: wordErodeSink 1.5s ease-in forwards;
+   /* Important to keep words from re-appearing if they are re-rendered before removal */
+  opacity: 0;
+  transform: translateY(10px) scale(0.9);
+}

--- a/src/TypeWriter.css
+++ b/src/TypeWriter.css
@@ -961,17 +961,27 @@
 @keyframes wordErodeSink {
   from {
     opacity: 1;
-    transform: translateY(0) scale(1);
+    transform: translateY(0) scale(1) rotateX(0);
+    filter: blur(0);
+  }
+  50% {
+    opacity: 0.6;
+    transform: translateY(15px) scale(0.85) rotateX(20deg); /* More sink, slight shrink and rotation */
+    filter: blur(0.5px);
   }
   to {
     opacity: 0;
-    transform: translateY(10px) scale(0.9);
+    transform: translateY(30px) scale(0.7) rotateX(45deg); /* Pronounced sink, shrink, and rotation */
+    filter: blur(1px);
   }
 }
 
 .word-eroding-sink {
-  animation: wordErodeSink 1.5s ease-in forwards;
-   /* Important to keep words from re-appearing if they are re-rendered before removal */
+  animation: wordErodeSink 1.8s ease-in forwards; /* Changed from 1.5s, ease-in can look good for sinking */
+   /* Keep final state properties to prevent flicker if re-rendered before removal */
   opacity: 0;
-  transform: translateY(10px) scale(0.9);
+  transform: translateY(30px) scale(0.7) rotateX(45deg);
+  filter: blur(1px);
 }
+
+[end of src/TypeWriter.css]

--- a/src/TypeWriter.css
+++ b/src/TypeWriter.css
@@ -984,4 +984,45 @@
   filter: blur(1px);
 }
 
+@keyframes wordDematerializeGhostly {
+  0% {
+    opacity: 1;
+    transform: scale(1) translateY(0) skewX(0);
+    filter: blur(0);
+    letter-spacing: normal;
+  }
+  20% {
+    opacity: 0.7;
+    transform: scale(1.05) translateY(-2px) skewX(0);
+    filter: blur(0.5px);
+    letter-spacing: normal;
+  }
+  40% {
+    opacity: 1;
+    transform: scale(1) translateY(0) skewX(0);
+    filter: blur(0);
+    letter-spacing: normal;
+  }
+  70% {
+    opacity: 0.4;
+    transform: scale(0.9) translateY(-5px) skewX(10deg);
+    letter-spacing: 1px;
+    filter: blur(1px);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(0.7) translateY(-10px) skewX(20deg);
+    letter-spacing: 2px;
+    filter: blur(2px);
+  }
+}
+
+.word-dematerializing-ghostly {
+  animation: wordDematerializeGhostly 2s ease-out forwards;
+  /* Final state properties to prevent flicker */
+  opacity: 0;
+  transform: scale(0.7) translateY(-10px) skewX(20deg);
+  letter-spacing: 2px;
+  filter: blur(2px);
+}
 [end of src/TypeWriter.css]

--- a/src/TypewriterFramework.jsx
+++ b/src/TypewriterFramework.jsx
@@ -37,6 +37,9 @@ const KEY_TEXTURE_REFRESH_INTERVAL = 20000; // ms
 const GHOST_KEY_TYPING_INTERVAL = 90; // ms
 const GHOSTWRITER_AI_TRIGGER_INTERVAL = 1000; // ms
 const SLIDE_DURATION_MS_ALREADY_DEFINED = 1200; // Already defined as SLIDE_DURATION_MS, kept for reference
+const WORD_EROSION_INTERVAL_MS = 200; // Time between starting erosion of one word and the next
+const WORD_ERASE_DELAY_MS = 1600; // Time from when a word starts eroding until it's erased (CSS animation is 1.5s)
+
 
 // Animation & Style Values
 const PAGE_SLIDE_X_OFFSET = -50; // Percentage for left slide
@@ -93,7 +96,6 @@ const pageTransitionActionTypes = {
   FINISH_SLIDE_ANIMATION: 'FINISH_SLIDE_ANIMATION',
   START_HISTORY_NAVIGATION: 'START_HISTORY_NAVIGATION',
   SET_SCROLL_MODE: 'SET_SCROLL_MODE',
-  // RESET_TRANSITION_STATE can be part of FINISH_SLIDE_ANIMATION or a separate action
 };
 
 const initialPageTransitionState = {
@@ -111,10 +113,7 @@ const initialPageTransitionState = {
 function pageTransitionReducer(state, action) {
   switch (action.type) {
     case pageTransitionActionTypes.START_PAGE_TURN_SCROLL:
-      return {
-        ...state,
-        pageChangeInProgress: true,
-      };
+      return { ...state, pageChangeInProgress: true };
     case pageTransitionActionTypes.PREPARE_SLIDE:
       return {
         ...state,
@@ -124,21 +123,16 @@ function pageTransitionReducer(state, action) {
         nextFilmBgUrl: action.payload.nextFilmBgUrl,
         nextText: action.payload.nextText,
         isSliding: true,
-        slideX: 0, // Reset slideX before starting animation
+        slideX: 0, 
       };
     case pageTransitionActionTypes.START_SLIDE_ANIMATION:
-      return {
-        ...state,
-        slideX: action.payload.slideX,
-      };
+      return { ...state, slideX: action.payload.slideX };
     case pageTransitionActionTypes.FINISH_SLIDE_ANIMATION:
       return {
         ...state,
         isSliding: false,
         pageChangeInProgress: false,
         scrollMode: action.payload.newScrollMode || INITIAL_SCROLL_MODE,
-        // typingAllowed and showCursor are not part of this reducer's state
-        // but the action causing this might also trigger those changes elsewhere
       };
     case pageTransitionActionTypes.START_HISTORY_NAVIGATION:
       return {
@@ -153,10 +147,7 @@ function pageTransitionReducer(state, action) {
         slideX: 0,
       };
     case pageTransitionActionTypes.SET_SCROLL_MODE:
-      return {
-        ...state,
-        scrollMode: action.payload.scrollMode,
-      };
+      return { ...state, scrollMode: action.payload.scrollMode };
     default:
       return state;
   }
@@ -187,7 +178,7 @@ function ghostwriterReducer(state, action) {
     case ghostwriterActionTypes.RESET_GHOSTWRITER_STATE:
       return {
         ...initialGhostwriterState,
-        lastUserInputTime: Date.now(), // Reset time to now
+        lastUserInputTime: Date.now(), 
       };
     default:
       return state;
@@ -199,28 +190,49 @@ const typingActionTypes = {
   SET_TYPING_ALLOWED: 'SET_TYPING_ALLOWED',
   SET_SHOW_CURSOR: 'SET_SHOW_CURSOR',
   ADD_TO_INPUT_BUFFER: 'ADD_TO_INPUT_BUFFER',
-  CONSUME_INPUT_BUFFER: 'CONSUME_INPUT_BUFFER', // Removes the first char
+  CONSUME_INPUT_BUFFER: 'CONSUME_INPUT_BUFFER', 
   SET_LAST_PRESSED_KEY: 'SET_LAST_PRESSED_KEY',
   CLEAR_LAST_PRESSED_KEY: 'CLEAR_LAST_PRESSED_KEY',
-  ADD_RESPONSE: 'ADD_RESPONSE', // payload: { id: string, content: string (initially empty) }
-  UPDATE_LAST_RESPONSE_CONTENT: 'UPDATE_LAST_RESPONSE_CONTENT', // payload: char to append
+  ADD_RESPONSE: 'ADD_RESPONSE', 
+  UPDATE_LAST_RESPONSE_CONTENT: 'UPDATE_LAST_RESPONSE_CONTENT', 
   CLEAR_RESPONSES: 'CLEAR_RESPONSES',
-  SET_GHOST_KEY_QUEUE: 'SET_GHOST_KEY_QUEUE', // payload: array of chars
-  CONSUME_GHOST_KEY_QUEUE: 'CONSUME_GHOST_KEY_QUEUE', // Removes the first char
-  RESET_TYPING_STATE_FOR_NEW_PAGE: 'RESET_TYPING_STATE_FOR_NEW_PAGE', // Resets responses, ghostKeyQueue
+  SET_GHOST_KEY_QUEUE: 'SET_GHOST_KEY_QUEUE', 
+  CONSUME_GHOST_KEY_QUEUE: 'CONSUME_GHOST_KEY_QUEUE', 
+  RESET_TYPING_STATE_FOR_NEW_PAGE: 'RESET_TYPING_STATE_FOR_NEW_PAGE', 
   HANDLE_BACKSPACE: 'HANDLE_BACKSPACE',
   RESET_PAGE_TEXT_UPDATE_REQUEST: 'RESET_PAGE_TEXT_UPDATE_REQUEST',
+  PREPARE_GHOST_WORDS_FOR_EROSION: 'PREPARE_GHOST_WORDS_FOR_EROSION',
+  SET_GHOST_WORD_ERODING: 'SET_GHOST_WORD_ERODING',
+  SET_GHOST_WORD_ERASED: 'SET_GHOST_WORD_ERASED',
+  RESET_EROSION_STATE: 'RESET_EROSION_STATE',
 };
 
 const initialTypingState = {
   inputBuffer: '',
   typingAllowed: true,
   lastPressedKey: null,
-  responses: [], // Array of objects, e.g., { id: 'someId', content: 'response text' }
+  responses: [], 
   ghostKeyQueue: [],
   showCursor: true,
-  requestPageTextUpdate: false, // Flag for backspace needing page text modification
+  requestPageTextUpdate: false, 
+  ghostWords: [], 
+  isGhostTextStable: false,
+  displayableGhostText: '',
 };
+
+// Helper to build displayableGhostText from ghostWords
+const buildDisplayableGhostText = (ghostWords) => {
+  return ghostWords.map(word => {
+    if (word.status === 'eroding') {
+      return `<span class="word-eroding-fadeout">${word.text}</span>`;
+    }
+    if (word.status === 'visible') {
+      return word.text;
+    }
+    return ''; // Erased words contribute nothing
+  }).filter(Boolean).join(' '); // Filter out empty strings from erased words and join
+};
+
 
 function typingReducer(state, action) {
   switch (action.type) {
@@ -247,7 +259,14 @@ function typingReducer(state, action) {
       );
       return { ...state, responses: updatedResponses, requestPageTextUpdate: false };
     case typingActionTypes.CLEAR_RESPONSES:
-      return { ...state, responses: [], requestPageTextUpdate: false };
+      return { 
+        ...state, 
+        responses: [], 
+        requestPageTextUpdate: false,
+        ghostWords: [],
+        isGhostTextStable: false,
+        displayableGhostText: ''
+      };
     case typingActionTypes.SET_GHOST_KEY_QUEUE:
       return { ...state, ghostKeyQueue: action.payload, requestPageTextUpdate: false };
     case typingActionTypes.CONSUME_GHOST_KEY_QUEUE:
@@ -257,21 +276,68 @@ function typingReducer(state, action) {
         ...state,
         responses: [],
         ghostKeyQueue: [],
-        inputBuffer: '', // Also clear input buffer on new page
+        inputBuffer: '', 
         requestPageTextUpdate: false,
+        ghostWords: [],
+        isGhostTextStable: false,
+        displayableGhostText: ''
       };
     case typingActionTypes.HANDLE_BACKSPACE:
       if (state.inputBuffer.length > 0) {
         return { ...state, inputBuffer: state.inputBuffer.slice(0, -1), requestPageTextUpdate: false };
       }
       if (state.responses.length > 0) {
-        // Clear responses and ghost queue if backspace is hit with active ghost text
-        return { ...state, responses: [], ghostKeyQueue: [], requestPageTextUpdate: false };
+        return { 
+          ...state, 
+          responses: [], 
+          ghostKeyQueue: [], 
+          requestPageTextUpdate: false,
+          ghostWords: [],
+          isGhostTextStable: false,
+          displayableGhostText: ''
+        };
       }
-      // If buffer and responses are empty, request page text update
       return { ...state, requestPageTextUpdate: true };
     case typingActionTypes.RESET_PAGE_TEXT_UPDATE_REQUEST:
       return { ...state, requestPageTextUpdate: false };
+    case typingActionTypes.PREPARE_GHOST_WORDS_FOR_EROSION:
+      const words = action.payload.split(' ').filter(word => word.length > 0);
+      const newGhostWords = words.map((word, index) => ({
+        text: word,
+        status: 'visible',
+        id: `${Date.now()}-${index}` 
+      }));
+      return {
+        ...state,
+        ghostWords: newGhostWords,
+        isGhostTextStable: true,
+        displayableGhostText: buildDisplayableGhostText(newGhostWords)
+      };
+    case typingActionTypes.SET_GHOST_WORD_ERODING:
+      const erodingWords = state.ghostWords.map(gw =>
+        gw.id === action.payload.wordId ? { ...gw, status: 'eroding' } : gw
+      );
+      return {
+        ...state,
+        ghostWords: erodingWords,
+        displayableGhostText: buildDisplayableGhostText(erodingWords)
+      };
+    case typingActionTypes.SET_GHOST_WORD_ERASED:
+      const erasedWords = state.ghostWords.map(gw =>
+        gw.id === action.payload.wordId ? { ...gw, status: 'erased' } : gw
+      );
+      return {
+        ...state,
+        ghostWords: erasedWords,
+        displayableGhostText: buildDisplayableGhostText(erasedWords)
+      };
+    case typingActionTypes.RESET_EROSION_STATE:
+      return {
+        ...state,
+        ghostWords: [],
+        isGhostTextStable: false,
+        displayableGhostText: ''
+      };
     default:
       return state;
   }
@@ -285,10 +351,9 @@ const keys = [
 ];
 
 const TypewriterFramework = () => {
-  // --- Reducers ---
   const [pageTransitionState, dispatchPageTransition] = useReducer(pageTransitionReducer, initialPageTransitionState);
   const {
-    scrollMode, // Note: scrollMode is part of pageTransitionState, not typingState
+    scrollMode, 
     pageChangeInProgress,
     isSliding,
     slideX,
@@ -307,6 +372,9 @@ const TypewriterFramework = () => {
     responses,
     ghostKeyQueue,
     showCursor,
+    ghostWords,
+    isGhostTextStable,
+    displayableGhostText,
   } = typingState;
 
   const [ghostwriterState, dispatchGhostwriter] = useReducer(ghostwriterReducer, initialGhostwriterState);
@@ -316,28 +384,17 @@ const TypewriterFramework = () => {
     lastGeneratedLength,
   } = ghostwriterState;
 
-
-  // --- Page History State (Still useState as per instructions) ---
-  const [pages, setPages] = useState([
-    { text: '', filmBgUrl: DEFAULT_FILM_BG_URL }
-  ]);
+  const [pages, setPages] = useState([{ text: '', filmBgUrl: DEFAULT_FILM_BG_URL }]);
   const [currentPage, setCurrentPage] = useState(0);
-
-  // --- Other State ---
-  const [keyTextures, setKeyTextures] = useState(keys.map(getRandomTexture)); // UI specific, might remain useState
-  // lastUserInputTime, responseQueued, lastGeneratedLength are now in ghostwriterState
-  // Level: 0 = empty, 3 = full (ready for page turn)
+  const [keyTextures, setKeyTextures] = useState(keys.map(getRandomTexture)); 
   const [leverLevel, setLeverLevel] = useState(0);
-
-
-
   const SLIDE_DURATION_MS = 1200;
 
-  // --- Refs ---
   const containerRef = useRef(null);
   const scrollRef = useRef(null);
   const lastLineRef = useRef(null);
   const strikerRef = useRef(null);
+  const erosionTimeoutRef = useRef(null); 
 
   const [sessionId] = useState(() => {
     const stored = localStorage.getItem(SESSION_ID_STORAGE_KEY);
@@ -347,15 +404,15 @@ const TypewriterFramework = () => {
     return newId;
   });
 
-  // --- Derived ---
   const { text: pageText, filmBgUrl: pageBg } = pages[currentPage] || {};
-  // Ghost text is now derived from typingState.responses
-  const ghostText = typingState.responses.length > 0 ? typingState.responses[typingState.responses.length - 1]?.content || '' : '';
-  const visibleLineCount = Math.min(countLines(pageText, ghostText), MAX_LINES);
+  const ghostTextForDisplay = isGhostTextStable 
+    ? displayableGhostText 
+    : (responses.length > 0 ? responses[responses.length - 1]?.content || '' : '');
+  
+  const visibleLineCount = Math.min(countLines(pageText, ghostTextForDisplay), MAX_LINES);
   const neededHeight = TOP_OFFSET + visibleLineCount * LINE_HEIGHT + NEEDED_HEIGHT_OFFSET;
   const scrollAreaHeight = Math.max(FRAME_HEIGHT, neededHeight);
 
-  // --- Cinematic Scroll intro ---
   useEffect(() => {
     if (pageTransitionState.scrollMode !== INITIAL_SCROLL_MODE || !scrollRef.current) return;
     scrollRef.current.scrollTop = 0;
@@ -374,16 +431,13 @@ const TypewriterFramework = () => {
     function animateScroll(now) {
       const elapsed = now - startTime;
       const progress = Math.min(elapsed / duration, 1);
-      const ease = progress < 0.5
-        ? 4 * progress * progress * progress
-        : 1 - Math.pow(-2 * progress + 2, 3) / 2;
+      const ease = progress < 0.5 ? 4 * progress * progress * progress : 1 - Math.pow(-2 * progress + 2, 3) / 2;
       ref.current.scrollTop = start + change * ease;
       if (progress < 1) requestAnimationFrame(animateScroll);
     }
     requestAnimationFrame(animateScroll);
   }
 
-  // --- Unified scroll effect ---
   useEffect(() => {
     if (!scrollRef.current || !lastLineRef.current) return;
     if (pageTransitionState.scrollMode === NORMAL_SCROLL_MODE) {
@@ -391,67 +445,41 @@ const TypewriterFramework = () => {
         lastLineRef.current.scrollIntoView({ behavior: "smooth", block: "nearest" });
       });
     }
-  }, [pageText, ghostText, responses, pageTransitionState.scrollMode]);
+  }, [pageText, ghostTextForDisplay, responses, pageTransitionState.scrollMode]); 
 
-  // --- PAGE TURN: Scroll up, then slide left (NEW PAGE) ---
   const handlePageTurnScroll = async () => {
-    if (pageTransitionState.pageChangeInProgress) return;
+    if (pageChangeInProgress) return;
     dispatchPageTransition({ type: pageTransitionActionTypes.START_PAGE_TURN_SCROLL });
     dispatchTyping({ type: typingActionTypes.SET_TYPING_ALLOWED, payload: false });
     dispatchTyping({ type: typingActionTypes.SET_SHOW_CURSOR, payload: false });
     playEndOfPageSound();
-
-    // Animate scroll up
     if (scrollRef.current) {
       const start = scrollRef.current.scrollTop;
       const duration = PAGE_TURN_SCROLL_ANIMATION_DURATION;
       const startTime = performance.now();
-
       function animateScroll(now) {
         const elapsed = now - startTime;
         const progress = Math.min(elapsed / duration, 1);
-        const ease = 1 - Math.pow(1 - progress, 3); // ease-out cubic
+        const ease = 1 - Math.pow(1 - progress, 3); 
         scrollRef.current.scrollTop = start - start * ease;
         if (progress < 1) {
           requestAnimationFrame(animateScroll);
         } else {
           scrollRef.current.scrollTop = 0;
-
-          // Fetch next film image then prepare for slide
-          fetchNextFilmImage(pageText + ghostText, sessionId).then(data => {
+          fetchNextFilmImage(pageText + ghostTextForDisplay, sessionId).then(data => { 
             const newUrl = data?.data.image_url || null;
             const newFilm = newUrl || DEFAULT_FILM_BG_URL;
-            
             dispatchPageTransition({
               type: pageTransitionActionTypes.PREPARE_SLIDE,
-              payload: {
-                slideDir: SLIDE_DIRECTION_LEFT,
-                prevFilmBgUrl: pageBg,
-                prevText: pageText,
-                nextFilmBgUrl: newFilm,
-                nextText: '', // New page is blank
-              }
+              payload: { slideDir: SLIDE_DIRECTION_LEFT, prevFilmBgUrl: pageBg, prevText: pageText, nextFilmBgUrl: newFilm, nextText: '' }
             });
-
-            // Update pages: Add new blank page, move to it
-            setPages(prev => [
-              ...prev.slice(0, currentPage + 1),
-              { text: '', filmBgUrl: newFilm }
-            ]);
+            setPages(prev => [...prev.slice(0, currentPage + 1),{ text: '', filmBgUrl: newFilm }]);
             setCurrentPage(prev => prev + 1);
-            
             requestAnimationFrame(() => {
-              dispatchPageTransition({
-                type: pageTransitionActionTypes.START_SLIDE_ANIMATION,
-                payload: { slideX: PAGE_SLIDE_X_OFFSET }
-              });
+              dispatchPageTransition({ type: pageTransitionActionTypes.START_SLIDE_ANIMATION, payload: { slideX: PAGE_SLIDE_X_OFFSET } });
             });
-
             setTimeout(() => {
-              dispatchPageTransition({
-                type: pageTransitionActionTypes.FINISH_SLIDE_ANIMATION,
-                payload: { newScrollMode: INITIAL_SCROLL_MODE }
-              });
+              dispatchPageTransition({ type: pageTransitionActionTypes.FINISH_SLIDE_ANIMATION, payload: { newScrollMode: INITIAL_SCROLL_MODE } });
               dispatchTyping({ type: typingActionTypes.SET_TYPING_ALLOWED, payload: true });
               dispatchTyping({ type: typingActionTypes.SET_SHOW_CURSOR, payload: true });
               dispatchTyping({ type: typingActionTypes.RESET_TYPING_STATE_FOR_NEW_PAGE });
@@ -464,16 +492,12 @@ const TypewriterFramework = () => {
     }
   };
 
-  // --- PAGE TURN: Slide right (BACK/NEXT in history) ---
   const handleHistoryNavigation = (targetIdx) => {
-    if (pageTransitionState.pageChangeInProgress || pageTransitionState.isSliding) return;
-
+    if (pageChangeInProgress || isSliding) return;
     dispatchTyping({ type: typingActionTypes.SET_TYPING_ALLOWED, payload: false });
     dispatchTyping({ type: typingActionTypes.SET_SHOW_CURSOR, payload: false });
-
     const toNext = targetIdx > currentPage;
     const targetPage = pages[targetIdx];
-
     dispatchPageTransition({
       type: pageTransitionActionTypes.START_HISTORY_NAVIGATION,
       payload: {
@@ -484,20 +508,12 @@ const TypewriterFramework = () => {
         nextText: targetPage?.text || '',
       }
     });
-    
     requestAnimationFrame(() => {
-      dispatchPageTransition({
-        type: pageTransitionActionTypes.START_SLIDE_ANIMATION,
-        payload: { slideX: toNext ? PAGE_SLIDE_X_OFFSET : -PAGE_SLIDE_X_OFFSET }
-      });
+      dispatchPageTransition({ type: pageTransitionActionTypes.START_SLIDE_ANIMATION, payload: { slideX: toNext ? PAGE_SLIDE_X_OFFSET : -PAGE_SLIDE_X_OFFSET } });
     });
-
     setTimeout(() => {
-      setCurrentPage(targetIdx); // Update current page after slide
-      dispatchPageTransition({
-        type: pageTransitionActionTypes.FINISH_SLIDE_ANIMATION,
-        payload: { newScrollMode: INITIAL_SCROLL_MODE }
-      });
+      setCurrentPage(targetIdx); 
+      dispatchPageTransition({ type: pageTransitionActionTypes.FINISH_SLIDE_ANIMATION, payload: { newScrollMode: INITIAL_SCROLL_MODE } });
       dispatchTyping({ type: typingActionTypes.SET_TYPING_ALLOWED, payload: (targetIdx === pages.length - 1) });
       dispatchTyping({ type: typingActionTypes.SET_SHOW_CURSOR, payload: true });
       dispatchTyping({ type: typingActionTypes.RESET_TYPING_STATE_FOR_NEW_PAGE });
@@ -505,15 +521,16 @@ const TypewriterFramework = () => {
     }, SLIDE_DURATION_MS);
   };
 
-  // --- Keyboard Handler ---
   const handleKeyDown = (e) => {
-    if (pageTransitionState.pageChangeInProgress || !typingState.typingAllowed) {
+    if (pageChangeInProgress || !typingAllowed) {
       playEndOfPageSound();
       return;
     }
+    if (isGhostTextStable) { 
+        dispatchTyping({ type: typingActionTypes.RESET_EROSION_STATE });
+    }
     const char = e.key === "Enter" ? '\n' : e.key;
-    // Use typingState.inputBuffer and typingState.responses for currentLines calculation
-    const currentLines = (pageText + ghostText + typingState.inputBuffer).split('\n').length;
+    const currentLines = (pageText + ghostTextForDisplay + inputBuffer).split('\n').length;
     if (currentLines >= MAX_LINES && e.key !== 'Backspace') {
       handlePageTurnScroll();
       return;
@@ -524,366 +541,243 @@ const TypewriterFramework = () => {
 
     if (e.key.length === 1 || e.key === "Enter") {
       e.preventDefault();
-      if (typingState.responses.length > 0) {
-        commitGhostText(); // commitGhostText will now use typingState.responses
+      if (responses.length > 0 && !isGhostTextStable) { 
+        commitGhostText(); 
       }
       dispatchTyping({ type: typingActionTypes.ADD_TO_INPUT_BUFFER, payload: char });
       if (e.key === "Enter") playEnterSound();
       else playKeySound();
-      return; // Return after handling Enter or character input
+      return; 
     }
 
     if (e.key === 'Backspace') {
       e.preventDefault();
-      const oldInputBufferLength = typingState.inputBuffer.length;
-      const oldResponsesLength = typingState.responses.length;
-
-      dispatchTyping({ type: typingActionTypes.HANDLE_BACKSPACE });
-      
-      // We need to check the state *after* dispatch, but handleKeyDown doesn't have access to it immediately.
-      // So, we rely on the `requestPageTextUpdate` flag that will be set in the state by the reducer.
-      // This check will happen in an effect or based on the new state in the next render.
-      // For now, let's assume if inputBuffer and responses were empty, page text needs update.
+      const oldInputBufferLength = inputBuffer.length;
+      const oldResponsesLength = responses.length;
+      dispatchTyping({ type: typingActionTypes.HANDLE_BACKSPACE }); 
       if (oldInputBufferLength === 0 && oldResponsesLength === 0) {
         setPages(prev => {
           const updatedPages = [...prev];
           if (updatedPages[currentPage] && updatedPages[currentPage].text.length > 0) {
-            updatedPages[currentPage] = {
-              ...updatedPages[currentPage],
-              text: updatedPages[currentPage].text.slice(0, -1)
-            };
+            updatedPages[currentPage] = { ...updatedPages[currentPage], text: updatedPages[currentPage].text.slice(0, -1) };
           }
           return updatedPages;
         });
       }
       playKeySound();
-      return; // Return after handling Backspace
+      return; 
     }
-    
-    // For other keys not handled above (like Shift, Ctrl, etc.)
-    // playKeySound() was here, but it should only play for printable characters or specific control keys.
-    // For now, let's assume other keys don't play sounds unless specifically handled.
-    // If specific other keys should play sounds, they need explicit handling.
   };
 
-  // Effect to handle page text update request from backspace
   useEffect(() => {
     if (typingState.requestPageTextUpdate) {
-      // This logic is now effectively duplicated from handleKeyDown.
-      // The original idea was that the reducer signals, and then the component acts.
-      // However, the action of modifying `pages` state is better kept in the event handler
-      // that has the immediate context.
-      // The `requestPageTextUpdate` flag can be used by `handleKeyDown` to know if `setPages` is needed.
-      // For now, this effect will just reset the flag. The actual page update logic
-      // is now intended to be in handleKeyDown based on prior state.
       dispatchTyping({ type: typingActionTypes.RESET_PAGE_TEXT_UPDATE_REQUEST });
     }
   }, [typingState.requestPageTextUpdate, dispatchTyping, setPages, currentPage]);
 
-
-  // --- Typing: apply inputBuffer to current page text ---
   useEffect(() => {
-    if (!typingState.inputBuffer.length || !typingState.typingAllowed) return;
-    const charToCommit = typingState.inputBuffer[0];
+    if (!inputBuffer.length || !typingAllowed) return;
+    const charToCommit = inputBuffer[0];
     const timeout = setTimeout(() => {
       setPages(prev => {
-        const updatedPages = [...prev];
-        updatedPages[currentPage] = {
-          ...updatedPages[currentPage],
-          text: updatedPages[currentPage].text + charToCommit
-        };
-        return updatedPages;
+        const newPages = [...prev];
+        newPages[currentPage] = { ...newPages[currentPage], text: newPages[currentPage].text + charToCommit };
+        return newPages;
       });
       dispatchTyping({ type: typingActionTypes.CONSUME_INPUT_BUFFER });
       if (charToCommit === '\n' && strikerRef.current) {
         strikerRef.current.classList.add('striker-return');
-        setTimeout(() => {
-          if (strikerRef.current) {
-            strikerRef.current.classList.remove('striker-return');
-          }
-        }, STRIKER_RETURN_ANIMATION_DURATION);
+        setTimeout(() => strikerRef.current?.classList.remove('striker-return'), STRIKER_RETURN_ANIMATION_DURATION);
       }
     }, TYPING_ANIMATION_INTERVAL);
     return () => clearTimeout(timeout);
-  }, [typingState.inputBuffer, typingState.typingAllowed, currentPage, setPages]); // Added setPages to dependencies
+  }, [inputBuffer, typingAllowed, currentPage, setPages]); 
 
-  // --- Key Visual State ---
   useEffect(() => {
-    if (!typingState.lastPressedKey) return;
+    if (!lastPressedKey) return;
     const timeout = setTimeout(() => dispatchTyping({ type: typingActionTypes.CLEAR_LAST_PRESSED_KEY }), LAST_PRESSED_KEY_TIMEOUT);
     return () => clearTimeout(timeout);
-  }, [typingState.lastPressedKey]);
+  }, [lastPressedKey]);
 
-  // --- Key Texture Refresh ---
   useEffect(() => {
     const interval = setInterval(() => {
       const idx = Math.floor(Math.random() * keyTextures.length);
       setKeyTextures(prev => {
         const updated = [...prev];
-        const key = keys[idx];
-        updated[idx] = getRandomTexture(key);
+        updated[idx] = getRandomTexture(keys[idx]);
         return updated;
       });
     }, KEY_TEXTURE_REFRESH_INTERVAL);
     return () => clearInterval(interval);
   }, [keyTextures]);
 
-  // --- Ghost Key Typing Simulation ---
   useEffect(() => {
-    if (!typingState.ghostKeyQueue.length || !typingState.typingAllowed) return;
-    const interval = setInterval(() => {
-      const charToAppend = typingState.ghostKeyQueue[0];
-      if (charToAppend) {
-        // Append the character to the last response's content
-        dispatchTyping({ type: typingActionTypes.UPDATE_LAST_RESPONSE_CONTENT, payload: charToAppend });
-      }
-      dispatchTyping({ type: typingActionTypes.CONSUME_GHOST_KEY_QUEUE });
-    }, GHOST_KEY_TYPING_INTERVAL);
-    return () => clearInterval(interval);
-  }, [typingState.ghostKeyQueue, typingState.typingAllowed]);
-
-  // --- Ghostwriter AI Trigger ---
-useEffect(() => {
-  if (!typingState.typingAllowed) return;
-  const interval = setInterval(async () => {
-    const fullText = pages[currentPage]?.text || '';
-    // Use ghostwriterState for lastGeneratedLength and lastUserInputTime
-    const addition = fullText.slice(ghostwriterState.lastGeneratedLength);
-    const pauseSeconds = (Date.now() - ghostwriterState.lastUserInputTime) / 1000;
-
-    // Use ghostwriterState.responseQueued
-    if (addition.trim().split(/\s+/).length >= GHOSTWRITER_MIN_WORDS_TRIGGER && !ghostwriterState.responseQueued) {
-      const data = await fetchShouldGenerateContinuation(fullText, addition, pauseSeconds);
-      const shouldGenerate = data.data.shouldGenerate
-      if (shouldGenerate) {
-        const resp = await fetchTypewriterReply(fullText, sessionId);
-        const reply = resp.data
-        if (reply && reply.content) {
-          dispatchTyping({ type: typingActionTypes.ADD_RESPONSE, payload: { ...reply, id: Date.now().toString(), content: '' } });
-          dispatchTyping({ type: typingActionTypes.SET_GHOST_KEY_QUEUE, payload: reply.content.split('') });
-          // Dispatch updates to ghostwriterState
-          dispatchGhostwriter({ type: ghostwriterActionTypes.SET_LAST_GENERATED_LENGTH, payload: fullText.length });
-          dispatchGhostwriter({ type: ghostwriterActionTypes.SET_RESPONSE_QUEUED, payload: true });
+    if (!typingAllowed) return;
+    let interval;
+    if (ghostKeyQueue.length > 0) {
+      interval = setInterval(() => {
+        const charToAppend = ghostKeyQueue[0];
+        if (charToAppend) {
+          dispatchTyping({ type: typingActionTypes.UPDATE_LAST_RESPONSE_CONTENT, payload: charToAppend });
         }
+        dispatchTyping({ type: typingActionTypes.CONSUME_GHOST_KEY_QUEUE });
+      }, GHOST_KEY_TYPING_INTERVAL);
+    } else if (responses.length > 0 && !isGhostTextStable) {
+      const lastResponseContent = responses[responses.length - 1].content;
+      if (lastResponseContent) {
+        dispatchTyping({ type: typingActionTypes.PREPARE_GHOST_WORDS_FOR_EROSION, payload: lastResponseContent });
       }
     }
-  }, GHOSTWRITER_AI_TRIGGER_INTERVAL);
-  return () => clearInterval(interval);
-  // Dependencies now include relevant parts of ghostwriterState
-}, [pages, currentPage, typingState.typingAllowed, ghostwriterState.lastUserInputTime, ghostwriterState.responseQueued, ghostwriterState.lastGeneratedLength, sessionId, dispatchTyping, dispatchGhostwriter]);
+    return () => clearInterval(interval);
+  }, [ghostKeyQueue, typingAllowed, responses, isGhostTextStable, dispatchTyping]);
 
+  useEffect(() => {
+    if (isGhostTextStable && typingAllowed) {
+      const visibleWords = ghostWords.filter(gw => gw.status === 'visible');
+      if (visibleWords.length > 0) {
+        if (erosionTimeoutRef.current) {
+          clearTimeout(erosionTimeoutRef.current);
+        }
+        erosionTimeoutRef.current = setTimeout(() => {
+          const randomIndex = Math.floor(Math.random() * visibleWords.length);
+          const wordToErode = visibleWords[randomIndex];
+          dispatchTyping({ type: typingActionTypes.SET_GHOST_WORD_ERODING, payload: { wordId: wordToErode.id } });
+          setTimeout(() => {
+            dispatchTyping({ type: typingActionTypes.SET_GHOST_WORD_ERASED, payload: { wordId: wordToErode.id } });
+          }, WORD_ERASE_DELAY_MS);
+        }, WORD_EROSION_INTERVAL_MS); 
+      }
+    }
+    return () => {
+      if (erosionTimeoutRef.current) {
+        clearTimeout(erosionTimeoutRef.current);
+      }
+    };
+  }, [isGhostTextStable, ghostWords, typingAllowed, dispatchTyping]);
 
-  // --- Commit Ghost Text ---
+  useEffect(() => {
+    if (!typingAllowed) return;
+    const interval = setInterval(async () => {
+      const fullText = pages[currentPage]?.text || '';
+      const addition = fullText.slice(lastGeneratedLength);
+      const pauseSeconds = (Date.now() - lastUserInputTime) / 1000;
+      if (addition.trim().split(/\s+/).length >= GHOSTWRITER_MIN_WORDS_TRIGGER && !responseQueued) {
+        const data = await fetchShouldGenerateContinuation(fullText, addition, pauseSeconds);
+        if (data.data.shouldGenerate) {
+          const resp = await fetchTypewriterReply(fullText, sessionId);
+          const reply = resp.data;
+          if (reply && reply.content) {
+            dispatchTyping({ type: typingActionTypes.RESET_EROSION_STATE }); 
+            dispatchTyping({ type: typingActionTypes.ADD_RESPONSE, payload: { ...reply, id: Date.now().toString(), content: '' } });
+            dispatchTyping({ type: typingActionTypes.SET_GHOST_KEY_QUEUE, payload: reply.content.split('') });
+            dispatchGhostwriter({ type: ghostwriterActionTypes.SET_LAST_GENERATED_LENGTH, payload: fullText.length });
+            dispatchGhostwriter({ type: ghostwriterActionTypes.SET_RESPONSE_QUEUED, payload: true });
+          }
+        }
+      }
+    }, GHOSTWRITER_AI_TRIGGER_INTERVAL);
+    return () => clearInterval(interval);
+  }, [pages, currentPage, typingAllowed, lastUserInputTime, responseQueued, lastGeneratedLength, sessionId, dispatchTyping, dispatchGhostwriter]);
+
   const commitGhostText = () => {
-    // Get ghost text from typingState.responses
-    const fullGhostText = typingState.responses.map(r => r.content).join('');
-    if (!fullGhostText) return; // No ghost text to commit
-
-    const mergedText = pageText + fullGhostText;
+    const fullGhostText = responses.map(r => r.content).join('');
+    if (!fullGhostText && !isGhostTextStable) return; 
+    let textToCommit = fullGhostText;
+    if (isGhostTextStable) { 
+        textToCommit = displayableGhostText;
+    }
+    if (!textToCommit) return;
+    const mergedText = pageText + textToCommit;
     const mergedLines = mergedText.split('\n').length;
-    const newTextForPage =
-      mergedLines > MAX_LINES
-        ? mergedText.split('\n').slice(0, MAX_LINES).join('\n')
-        : mergedText;
-
+    const newTextForPage = mergedLines > MAX_LINES ? mergedText.split('\n').slice(0, MAX_LINES).join('\n') : mergedText;
     setPages(prev => {
       const updatedPages = [...prev];
-      updatedPages[currentPage] = {
-        ...updatedPages[currentPage],
-        text: newTextForPage
-      };
+      updatedPages[currentPage] = { ...updatedPages[currentPage], text: newTextForPage };
       return updatedPages;
     });
-
-    // Reset responses and ghostKeyQueue in typingState
-    dispatchTyping({ type: typingActionTypes.CLEAR_RESPONSES });
+    dispatchTyping({ type: typingActionTypes.CLEAR_RESPONSES }); 
     dispatchTyping({ type: typingActionTypes.SET_GHOST_KEY_QUEUE, payload: [] });
+    dispatchTyping({ type: typingActionTypes.RESET_EROSION_STATE }); 
   };
 
-  // --- Focus on Mount ---
   useEffect(() => {
     containerRef.current?.focus();
   }, []);
 
-
   useEffect(() => {
-  // Example: lever increases by writing (customize to your story logic)
-  const text = pages[currentPage]?.text || '';
-  const words = text.trim().split(/\s+/).filter(Boolean).length;
-  let newLevel = 0;
-  if (words > LEVER_LEVEL_WORD_THRESHOLDS[3]) newLevel = 3;
-  else if (words > LEVER_LEVEL_WORD_THRESHOLDS[2]) newLevel = 2;
-  else if (words > LEVER_LEVEL_WORD_THRESHOLDS[1]) newLevel = 1;
-  else newLevel = LEVER_LEVEL_WORD_THRESHOLDS[0]; // Should be 0
-  setLeverLevel(newLevel);
-}, [pages, currentPage]);
+    const text = pages[currentPage]?.text || '';
+    const words = text.trim().split(/\s+/).filter(Boolean).length;
+    let newLevel = 0;
+    if (words >= LEVER_LEVEL_WORD_THRESHOLDS[3]) newLevel = 3;
+    else if (words >= LEVER_LEVEL_WORD_THRESHOLDS[2]) newLevel = 2;
+    else if (words >= LEVER_LEVEL_WORD_THRESHOLDS[1]) newLevel = 1;
+    setLeverLevel(newLevel);
+  }, [pages, currentPage]);
 
-
-  // --- Keyboard Event Handlers for <Keyboard /> component ---
   const handleRegularKeyPress = (keyText) => {
-    // If there's ghost text, commit it first, then add the new keyText
-    if (typingState.responses.length > 0) {
-      commitGhostText(); 
-      // After committing, the input should go to the page directly or input buffer
-      // For simplicity, let's assume direct page update after commit for now,
-      // or it could go to input buffer if that's the desired flow.
-      // This interaction might need further refinement.
-      // For now, let's add to input buffer.
-      dispatchTyping({ type: typingActionTypes.ADD_TO_INPUT_BUFFER, payload: keyText });
-    } else {
-      dispatchTyping({ type: typingActionTypes.ADD_TO_INPUT_BUFFER, payload: keyText });
-    }
+    if (isGhostTextStable) dispatchTyping({ type: typingActionTypes.RESET_EROSION_STATE });
+    if (responses.length > 0 && !isGhostTextStable) commitGhostText(); 
+    dispatchTyping({ type: typingActionTypes.ADD_TO_INPUT_BUFFER, payload: keyText });
     dispatchTyping({ type: typingActionTypes.SET_LAST_PRESSED_KEY, payload: keyText.toUpperCase() });
     playKeySound();
   };
 
   const handleXerofagKeyPress = () => {
-    if (typingState.responses.length > 0) {
-      commitGhostText();
-      dispatchTyping({ type: typingActionTypes.ADD_TO_INPUT_BUFFER, payload: SPECIAL_KEY_INSERT_TEXT });
-    } else {
-      dispatchTyping({ type: typingActionTypes.ADD_TO_INPUT_BUFFER, payload: SPECIAL_KEY_INSERT_TEXT });
-    }
+    if (isGhostTextStable) dispatchTyping({ type: typingActionTypes.RESET_EROSION_STATE });
+    if (responses.length > 0 && !isGhostTextStable) commitGhostText();
+    dispatchTyping({ type: typingActionTypes.ADD_TO_INPUT_BUFFER, payload: SPECIAL_KEY_INSERT_TEXT });
     dispatchTyping({ type: typingActionTypes.SET_LAST_PRESSED_KEY, payload: SPECIAL_KEY_TEXT.toUpperCase() });
     playXerofagHowl();
   };
 
   const handleSpacebarPress = () => {
-    // Similar to regular key press, commit ghost text if any
-    if (typingState.responses.length > 0) {
-      commitGhostText();
-      dispatchTyping({ type: typingActionTypes.ADD_TO_INPUT_BUFFER, payload: ' ' });
-    } else {
-      dispatchTyping({ type: typingActionTypes.ADD_TO_INPUT_BUFFER, payload: ' ' });
-    }
+    if (isGhostTextStable) dispatchTyping({ type: typingActionTypes.RESET_EROSION_STATE });
+    if (responses.length > 0 && !isGhostTextStable) commitGhostText();
+    dispatchTyping({ type: typingActionTypes.ADD_TO_INPUT_BUFFER, payload: ' ' });
     dispatchTyping({ type: typingActionTypes.SET_LAST_PRESSED_KEY, payload: ' ' });
     playKeySound();
   };
 
-  // --- RENDER ---
   return (
-    <div
-      className="typewriter-container"
-      tabIndex="0"
-      onKeyDown={handleKeyDown}
-      ref={containerRef}
-    >
+    <div className="typewriter-container" tabIndex="0" onKeyDown={handleKeyDown} ref={containerRef}>
       <PageNavigation
-        currentPage={currentPage}
-        totalPages={pages.length}
-        onPrevPage={() => handleHistoryNavigation(currentPage - 1)}
-        onNextPage={() => handleHistoryNavigation(currentPage + 1)}
-        isSliding={isSliding} // Directly from pageTransitionState
-        // Pass relevant styling constants
-        PAGE_NAVIGATION_BUTTONS_TOP={PAGE_NAVIGATION_BUTTONS_TOP}
-        PAGE_NAVIGATION_BUTTONS_Z_INDEX={PAGE_NAVIGATION_BUTTONS_Z_INDEX}
-        PAGE_NAVIGATION_BUTTONS_PADDING={PAGE_NAVIGATION_BUTTONS_PADDING}
-        PAGE_NAVIGATION_BUTTON_FONT_SIZE={PAGE_NAVIGATION_BUTTON_FONT_SIZE}
-        PAGE_NAVIGATION_BUTTON_DISABLED_OPACITY={PAGE_NAVIGATION_BUTTON_DISABLED_OPACITY}
-        PAGE_COUNT_TEXT_COLOR={PAGE_COUNT_TEXT_COLOR}
-        PAGE_COUNT_TEXT_FONT_FAMILY={PAGE_COUNT_TEXT_FONT_FAMILY}
-        PAGE_COUNT_TEXT_FONT_SIZE={PAGE_COUNT_TEXT_FONT_SIZE}
+        currentPage={currentPage} totalPages={pages.length}
+        onPrevPage={() => handleHistoryNavigation(currentPage - 1)} onNextPage={() => handleHistoryNavigation(currentPage + 1)}
+        isSliding={isSliding} PAGE_NAVIGATION_BUTTONS_TOP={PAGE_NAVIGATION_BUTTONS_TOP} PAGE_NAVIGATION_BUTTONS_Z_INDEX={PAGE_NAVIGATION_BUTTONS_Z_INDEX}
+        PAGE_NAVIGATION_BUTTONS_PADDING={PAGE_NAVIGATION_BUTTONS_PADDING} PAGE_NAVIGATION_BUTTON_FONT_SIZE={PAGE_NAVIGATION_BUTTON_FONT_SIZE}
+        PAGE_NAVIGATION_BUTTON_DISABLED_OPACITY={PAGE_NAVIGATION_BUTTON_DISABLED_OPACITY} PAGE_COUNT_TEXT_COLOR={PAGE_COUNT_TEXT_COLOR}
+        PAGE_COUNT_TEXT_FONT_FAMILY={PAGE_COUNT_TEXT_FONT_FAMILY} PAGE_COUNT_TEXT_FONT_SIZE={PAGE_COUNT_TEXT_FONT_SIZE}
       />
-
-      <img
-        src={GRIT_SHELL_OVERLAY_URL}
-        alt="grit shell overlay"
-        className="typewriter-overlay"
-      />
-
+      <img src={GRIT_SHELL_OVERLAY_URL} alt="grit shell overlay" className="typewriter-overlay" />
       <PaperDisplay
-        pageText={pageText}
-        ghostText={ghostText}
-        pageBg={pageBg}
-        scrollRef={scrollRef}
-        lastLineRef={lastLineRef}
-        strikerRef={strikerRef}
-        showCursor={showCursor}
-        isSliding={isSliding}
-        slideX={slideX}
-        slideDir={slideDir}
-        prevFilmBgUrl={prevFilmBgUrl}
-        nextFilmBgUrl={nextFilmBgUrl}
-        prevText={prevText}
-        nextText={nextText}
-        MAX_LINES={MAX_LINES}
-        TOP_OFFSET={TOP_OFFSET}
-        BOTTOM_PADDING={BOTTOM_PADDING}
-        FRAME_HEIGHT={FRAME_HEIGHT}
-        FILM_HEIGHT={FILM_HEIGHT}
-        scrollAreaHeight={scrollAreaHeight}
-        neededHeight={neededHeight}
-        SLIDE_DURATION_MS={SLIDE_DURATION_MS}
-        SPECIAL_KEY_TEXT={SPECIAL_KEY_TEXT}
-        // Pass all necessary animation/style constants used by PaperDisplay and its renderSlideWrapper
-        FILM_SLIDE_WRAPPER_WIDTH={FILM_SLIDE_WRAPPER_WIDTH}
-        FILM_SLIDE_WRAPPER_Z_INDEX={FILM_SLIDE_WRAPPER_Z_INDEX}
-        FILM_BG_SLIDE_OPACITY={FILM_BG_SLIDE_OPACITY}
-        FILM_BG_SLIDE_BOX_SHADOW_LEFT={FILM_BG_SLIDE_BOX_SHADOW_LEFT}
-        FILM_BG_SLIDE_BOX_SHADOW_RIGHT={FILM_BG_SLIDE_BOX_SHADOW_RIGHT}
-        FILM_BG_SLIDE_CONTRAST_OUTGOING={FILM_BG_SLIDE_CONTRAST_OUTGOING}
-        FILM_BG_SLIDE_BRIGHTNESS_OUTGOING={FILM_BG_SLIDE_BRIGHTNESS_OUTGOING}
-        FILM_BG_SLIDE_CONTRAST_INCOMING={FILM_BG_SLIDE_CONTRAST_INCOMING}
-        FILM_BG_SLIDE_BRIGHTNESS_INCOMING={FILM_BG_SLIDE_BRIGHTNESS_INCOMING}
-        FILM_FLICKER_OVERLAY_Z_INDEX={FILM_FLICKER_OVERLAY_Z_INDEX}
-        FILM_FLICKER_OVERLAY_TEXTURE_URL={FILM_FLICKER_OVERLAY_TEXTURE_URL}
-        FILM_FLICKER_OVERLAY_GRADIENT={FILM_FLICKER_OVERLAY_GRADIENT}
-        FILM_FLICKER_OVERLAY_OPACITY={FILM_FLICKER_OVERLAY_OPACITY}
-        FILM_FLICKER_OVERLAY_BLEND_MODE={FILM_FLICKER_OVERLAY_BLEND_MODE}
-        FILM_FLICKER_OVERLAY_ANIMATION={FILM_FLICKER_OVERLAY_ANIMATION}
-        FILM_BACKGROUND_Z_INDEX={FILM_BACKGROUND_Z_INDEX}
-        FILM_BACKGROUND_OPACITY={FILM_BACKGROUND_OPACITY}
-        TYPEWRITER_TEXT_Z_INDEX={TYPEWRITER_TEXT_Z_INDEX}
-        STRIKER_CURSOR_OFFSET_LEFT={STRIKER_CURSOR_OFFSET_LEFT}
-        SLIDE_DIRECTION_LEFT={SLIDE_DIRECTION_LEFT}
+        pageText={pageText} 
+        ghostText={ghostTextForDisplay} 
+        isGhostTextStable={isGhostTextStable} // Pass this prop
+        pageBg={pageBg} scrollRef={scrollRef} lastLineRef={lastLineRef} strikerRef={strikerRef}
+        showCursor={showCursor} isSliding={isSliding} slideX={slideX} slideDir={slideDir} prevFilmBgUrl={prevFilmBgUrl} nextFilmBgUrl={nextFilmBgUrl}
+        prevText={prevText} nextText={nextText} MAX_LINES={MAX_LINES} TOP_OFFSET={TOP_OFFSET} BOTTOM_PADDING={BOTTOM_PADDING} FRAME_HEIGHT={FRAME_HEIGHT}
+        FILM_HEIGHT={FILM_HEIGHT} scrollAreaHeight={scrollAreaHeight} neededHeight={neededHeight} SLIDE_DURATION_MS={SLIDE_DURATION_MS}
+        SPECIAL_KEY_TEXT={SPECIAL_KEY_TEXT} FILM_SLIDE_WRAPPER_WIDTH={FILM_SLIDE_WRAPPER_WIDTH} FILM_SLIDE_WRAPPER_Z_INDEX={FILM_SLIDE_WRAPPER_Z_INDEX}
+        FILM_BG_SLIDE_OPACITY={FILM_BG_SLIDE_OPACITY} FILM_BG_SLIDE_BOX_SHADOW_LEFT={FILM_BG_SLIDE_BOX_SHADOW_LEFT}
+        FILM_BG_SLIDE_BOX_SHADOW_RIGHT={FILM_BG_SLIDE_BOX_SHADOW_RIGHT} FILM_BG_SLIDE_CONTRAST_OUTGOING={FILM_BG_SLIDE_CONTRAST_OUTGOING}
+        FILM_BG_SLIDE_BRIGHTNESS_OUTGOING={FILM_BG_SLIDE_BRIGHTNESS_OUTGOING} FILM_BG_SLIDE_CONTRAST_INCOMING={FILM_BG_SLIDE_CONTRAST_INCOMING}
+        FILM_BG_SLIDE_BRIGHTNESS_INCOMING={FILM_BG_SLIDE_BRIGHTNESS_INCOMING} FILM_FLICKER_OVERLAY_Z_INDEX={FILM_FLICKER_OVERLAY_Z_INDEX}
+        FILM_FLICKER_OVERLAY_TEXTURE_URL={FILM_FLICKER_OVERLAY_TEXTURE_URL} FILM_FLICKER_OVERLAY_GRADIENT={FILM_FLICKER_OVERLAY_GRADIENT}
+        FILM_FLICKER_OVERLAY_OPACITY={FILM_FLICKER_OVERLAY_OPACITY} FILM_FLICKER_OVERLAY_BLEND_MODE={FILM_FLICKER_OVERLAY_BLEND_MODE}
+        FILM_FLICKER_OVERLAY_ANIMATION={FILM_FLICKER_OVERLAY_ANIMATION} FILM_BACKGROUND_Z_INDEX={FILM_BACKGROUND_Z_INDEX}
+        FILM_BACKGROUND_OPACITY={FILM_BACKGROUND_OPACITY} TYPEWRITER_TEXT_Z_INDEX={TYPEWRITER_TEXT_Z_INDEX}
+        STRIKER_CURSOR_OFFSET_LEFT={STRIKER_CURSOR_OFFSET_LEFT} SLIDE_DIRECTION_LEFT={SLIDE_DIRECTION_LEFT}
       />
-
-      <div className="storyteller-sigil">
-        <img
-          src={SIGIL_IMAGE_URL}
-          alt="Storyteller's Society Sigil"
-        />
-      </div>
-
+      <div className="storyteller-sigil"><img src={SIGIL_IMAGE_URL} alt="Storyteller's Society Sigil"/></div>
       <Keyboard
-        keys={keys}
-        keyTextures={keyTextures}
-        lastPressedKey={lastPressedKey}
-        typingAllowed={typingAllowed}
-        onKeyPress={handleRegularKeyPress}
-        onXerofagPress={handleXerofagKeyPress}
-        onSpacebarPress={handleSpacebarPress}
-        playEndOfPageSound={playEndOfPageSound} // Pass the function directly
-        // playKeySound and playXerofagHowl are called within the handlers above
-        // Props for styling randomization, if Keyboard component uses them:
-        KEY_TILT_RANDOM_MAX={KEY_TILT_RANDOM_MAX}
-        KEY_TILT_RANDOM_MIN={KEY_TILT_RANDOM_MIN}
-        KEY_OFFSET_Y_RANDOM_MAX={KEY_OFFSET_Y_RANDOM_MAX}
-        KEY_OFFSET_Y_RANDOM_MIN={KEY_OFFSET_Y_RANDOM_MIN}
-        SPECIAL_KEY_TEXT={SPECIAL_KEY_TEXT}
+        keys={keys} keyTextures={keyTextures} lastPressedKey={lastPressedKey} typingAllowed={typingAllowed}
+        onKeyPress={handleRegularKeyPress} onXerofagPress={handleXerofagKeyPress} onSpacebarPress={handleSpacebarPress}
+        playEndOfPageSound={playEndOfPageSound} KEY_TILT_RANDOM_MAX={KEY_TILT_RANDOM_MAX} KEY_TILT_RANDOM_MIN={KEY_TILT_RANDOM_MIN}
+        KEY_OFFSET_Y_RANDOM_MAX={KEY_OFFSET_Y_RANDOM_MAX} KEY_OFFSET_Y_RANDOM_MIN={KEY_OFFSET_Y_RANDOM_MIN} SPECIAL_KEY_TEXT={SPECIAL_KEY_TEXT}
       />
-
-      <div
-  className="turn-page-lever-float"
-  style={{
-    position: 'absolute',
-    bottom: TURN_PAGE_LEVER_BOTTOM,
-    left: TURN_PAGE_LEVER_LEFT,
-    zIndex: TURN_PAGE_LEVER_Z_INDEX,
-    pointerEvents: 'auto', // so user can click/tap lever!
-  }}
->
-  <TurnPageLever
-    level={leverLevel}
-    canPull={leverLevel === LEVER_LEVEL_WORD_THRESHOLDS.length -1 && !pageChangeInProgress && typingAllowed}
-    disabled={pageChangeInProgress}
-    onPull={() => {
-      setLeverLevel(0);
-      handlePageTurnScroll();
-    }}
-  />
-</div>
-
+      <div className="turn-page-lever-float" style={{position: 'absolute', bottom: TURN_PAGE_LEVER_BOTTOM, left: TURN_PAGE_LEVER_LEFT, zIndex: TURN_PAGE_LEVER_Z_INDEX, pointerEvents: 'auto'}}>
+        <TurnPageLever level={leverLevel} canPull={leverLevel === 3 && !pageChangeInProgress && typingAllowed} disabled={pageChangeInProgress} onPull={() => { setLeverLevel(0); handlePageTurnScroll(); }}/>
+      </div>
     </div>
   );
 };

--- a/src/TypewriterFramework.jsx
+++ b/src/TypewriterFramework.jsx
@@ -38,7 +38,7 @@ const GHOST_KEY_TYPING_INTERVAL = 90; // ms
 const GHOSTWRITER_AI_TRIGGER_INTERVAL = 1000; // ms
 const SLIDE_DURATION_MS_ALREADY_DEFINED = 1200; // Already defined as SLIDE_DURATION_MS, kept for reference
 const WORD_EROSION_INTERVAL_MS = 600; // Time between starting erosion of one word and the next
-const WORD_ERASE_DELAY_MS = 1900; // Time from when a word starts eroding until it's erased
+const WORD_ERASE_DELAY_MS = 2100; // Time from when a word starts eroding until it's erased (CSS animation is 2s)
 const EROSION_START_DELAY_PER_CHAR_MS = 10; // Delay before erosion starts, per character of ghost text
 
 
@@ -225,8 +225,7 @@ const initialTypingState = {
 const buildDisplayableGhostText = (ghostWords) => {
   return ghostWords.map(word => {
     if (word.status === 'eroding') {
-      // Ensure this uses the 'word-eroding-sink' class
-      return `<span class="word-eroding-sink">${word.text}</span>`;
+      return `<span class="word-dematerializing-ghostly">${word.text}</span>`;
     }
     if (word.status === 'visible') {
       return word.text;
@@ -325,14 +324,26 @@ function typingReducer(state, action) {
         displayableGhostText: buildDisplayableGhostText(erodingWords)
       };
     case typingActionTypes.SET_GHOST_WORD_ERASED:
-      const erasedWords = state.ghostWords.map(gw =>
+      const afterErasedWords = state.ghostWords.map(gw =>
         gw.id === action.payload.wordId ? { ...gw, status: 'erased' } : gw
       );
-      return {
-        ...state,
-        ghostWords: erasedWords,
-        displayableGhostText: buildDisplayableGhostText(erasedWords)
-      };
+      const allErased = afterErasedWords.length > 0 && afterErasedWords.every(gw => gw.status === 'erased');
+      
+      if (allErased) {
+        return {
+          ...state,
+          ghostWords: [], 
+          isGhostTextStable: false, 
+          displayableGhostText: '', 
+          responses: [] 
+        };
+      } else {
+        return {
+          ...state,
+          ghostWords: afterErasedWords,
+          displayableGhostText: buildDisplayableGhostText(afterErasedWords)
+        };
+      }
     case typingActionTypes.RESET_EROSION_STATE:
       return {
         ...state,


### PR DESCRIPTION
Adds a visual effect where AI-generated ghost text gradually dematerializes after appearing.

Key changes:

- CSS Animations: Introduced `@keyframes` and classes (`wordErodeFadeOut`, `wordErodeSink`) for word erosion effects in `src/TypeWriter.css`.
- State Management (`TypewriterFramework.jsx`):
    - Extended `typingReducer` to manage the state of individual ghost words (visible, eroding, erased) and track when ghost text is 'stable' (fully typed and ready for erosion).
    - Implemented logic to split ghost text into words and prepare them for erosion.
    - Added an effect hook to manage timers for randomly selecting words to erode and then marking them as erased after their animation.
- Rendering (`PaperDisplay.jsx`):
    - Modified to receive `isGhostTextStable` and ghost word information.
    - When ghost text is stable, it now renders pre-formatted HTML (from `TypewriterFramework`) containing spans with erosion classes for words currently eroding. This is done using `dangerouslySetInnerHTML`.
    - When ghost text is first appearing, it uses the existing character-by-character materialization animations.
- Coordination:
    - Ensured that the erosion process only starts after the initial ghost text typing animation is complete.
    - Your input or new AI-generated text correctly interrupts and resets any ongoing erosion effect.

This feature enhances the ghostwriter theme by making the AI's text feel more ephemeral and integrated into the narrative style of the typewriter.