### PR TITLE
Fix integration test import typo

### DIFF
--- a/src/TypewriterFramework.integration.test.js
+++ b/src/TypewriterFramework.integration.test.js
@@ -1,6 +1,6 @@
 // src/TypewriterFramework.integration.test.js
 import React from 'react';
-import { render, screen, fireEvent, waitFor, act }Cfrom '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import TypewriterFramework from './TypewriterFramework';
 import '@testing-library/jest-dom';
 import { MAX_LINES as ACTUAL_MAX_LINES, DEFAULT_FILM_BG_URL } from './TypewriterFramework'; // Import constants


### PR DESCRIPTION
## Summary
- fix syntax typo in `TypewriterFramework.integration.test.js`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f6a79ce008320b9ad1900db206b8a