### PR TITLE
Fix ghostwriter re-trigger

### DIFF
--- a/src/TypewriterFramework.jsx
+++ b/src/TypewriterFramework.jsx
@@ -843,6 +843,7 @@ useEffect(() => {
               dispatchTyping({ type: typingActionTypes.START_NEW_SEQUENCE, payload: reply.writing_sequence });
               dispatchGhostwriter({ type: ghostwriterActionTypes.SET_LAST_GENERATED_LENGTH, payload: fullText.length });
               dispatchGhostwriter({ type: ghostwriterActionTypes.SET_RESPONSE_QUEUED, payload: true });
+              dispatchGhostwriter({ type: ghostwriterActionTypes.UPDATE_LAST_USER_INPUT_TIME, payload: Date.now() });
             }
           }).catch(error => {
             console.error("Error fetching typewriter reply after shouldGenerate check:", error);


### PR DESCRIPTION
## Summary
- ensure ghostwriter timer resets when generating a continuation

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f6b0663b08320a9370d73facf9d9a