### PR TITLE
Fix redundant API calls

### DIFF
--- a/src/TypewriterFramework.jsx
+++ b/src/TypewriterFramework.jsx
@@ -897,7 +897,8 @@ const TypewriterFramework = () => {
       pauseSeconds >= 15 &&
       !typingState.isProcessingSequence &&
       typingState.inputBuffer.length === 0 &&
-      (fullText.length === ghostwriterState.lastGeneratedLength || ghostwriterState.lastGeneratedLength === 0)
+      (fullText.length === ghostwriterState.lastGeneratedLength || ghostwriterState.lastGeneratedLength === 0) &&
+      fullText.trim()
     ) {
       // (optional: you can disable this block if you never want inactivity autocompletion)
       fetchTypewriterReply(fullText, sessionId).then(response => {
@@ -917,7 +918,8 @@ const TypewriterFramework = () => {
     // --- USER-initiated continuation with GOLDEN RATIO THRESHOLD ---
    if (
   !typingState.isProcessingSequence &&
-  typingState.inputBuffer.length === 0 // Not while user is typing or ghostwriting
+  typingState.inputBuffer.length === 0 && // Not while user is typing or ghostwriting
+  addition.trim()
 ) {
   fetchShouldGenerateContinuation(
     fullText,

--- a/src/apiService.js
+++ b/src/apiService.js
@@ -20,6 +20,9 @@ export const fetchNextFilmImage = async (pageText, sessionId) => {
 };
 
 export const fetchTypewriterReply = async (text, sessionId) => {
+  if (!text) {
+    return { data: null, error: null };
+  }
   try {
     const response = await fetch(`${SERVER}/api/send_typewriter_text`, {
       method: "POST",
@@ -40,6 +43,9 @@ export const fetchTypewriterReply = async (text, sessionId) => {
 
 // Use axios or fetch—here’s a fetch version for clarity:
 export async function fetchShouldGenerateContinuation(currentText, latestAddition, latestPauseSeconds, lastGhostwriterWordCount) {
+  if (!latestAddition) {
+    return { data: { shouldGenerate: false }, error: null };
+  }
   const res = await fetch(`${SERVER}/api/shouldGenerateContinuation`, {
     method: 'POST',
     headers: {

--- a/src/apiService.test.js
+++ b/src/apiService.test.js
@@ -127,6 +127,13 @@ describe('apiService', () => {
         error: { message: 'Network connection lost' },
       });
     });
+
+    it('should not call fetch when text is empty', async () => {
+      const result = await fetchTypewriterReply('', sessionId);
+
+      expect(global.fetch).not.toHaveBeenCalled();
+      expect(result).toEqual({ data: null, error: null });
+    });
   });
 
   describe('fetchShouldGenerateContinuation', () => {
@@ -195,6 +202,13 @@ describe('apiService', () => {
         data: null,
         error: { message: 'Failed to connect' },
       });
+    });
+
+    it('should not call fetch when latestAddition is empty', async () => {
+      const result = await fetchShouldGenerateContinuation(currentText, '', latestPauseSeconds);
+
+      expect(global.fetch).not.toHaveBeenCalled();
+      expect(result).toEqual({ data: { shouldGenerate: false }, error: null });
     });
   });
 });


### PR DESCRIPTION
## Summary
- avoid calling fetchTypewriterReply when text is empty
- skip fetchShouldGenerateContinuation when no latest addition was typed
- guard for whitespace-only values when triggering ghostwriter
- add unit tests for these early return cases

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68415d23ecc08320a10218e91e366172