### PR TITLE
Fix: Implement correct typewriter fade behavior

### DIFF
--- a/src/TypeWriter.css
+++ b/src/TypeWriter.css
@@ -943,38 +943,21 @@
   }
 }
 
-@keyframes transformFadeInAnimation {
-  from {
-    opacity: 0;
-    filter: blur(2px);
-    transform: scale(0.95); /* Optional: slight scale up */
-  }
-  to {
-    opacity: 1;
-    filter: blur(0);
-    transform: scale(1);
-  }
-}
-
 .transform-fade-in {
-  animation: transformFadeInAnimation 0.5s ease-in forwards;
-  display: inline-block; /* Ensure it takes space */
+  animation: transformFadeInAnimation 1.2s cubic-bezier(.36,1.43,.6,.98) forwards;
+  opacity: 0;
 }
-
-@keyframes transformFadeOutAnimation {
-  from {
-    opacity: 1;
-    filter: blur(0);
-    transform: scale(1);
-  }
-  to {
-    opacity: 0;
-    filter: blur(2px);
-    transform: scale(0.95); /* Optional: slight scale down */
-  }
+@keyframes transformFadeInAnimation {
+  from { opacity: 0; filter: blur(4px); transform: scale(1.18) translateY(9px);}
+  to   { opacity: 1; filter: blur(0); transform: scale(1) translateY(0);}
 }
 
 .transform-fade-out {
-  animation: transformFadeOutAnimation 0.5s ease-out forwards;
-  display: inline-block; /* Ensure it takes space, especially if positioned absolutely */
+  animation: transformFadeOutAnimation 1.2s cubic-bezier(.36,1.43,.6,.98) forwards;
+  opacity: 1;
+  position: relative;
+}
+@keyframes transformFadeOutAnimation {
+  from { opacity: 1; filter: blur(0); transform: scale(1);}
+  to   { opacity: 0; filter: blur(2px); transform: scale(0.95);}
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -12,7 +12,7 @@ export const playKeySound = () => {
 
 export const playGhostWriterSound = () => {
   const roll = Math.floor(Math.random() * 2) + 1;
-  const audioSrc = roll === 1 ? '/sounds/ghostwriter_click1.mp3' : '/sounds/ghostwriter_clack2.mp3'; 
+  const audioSrc = roll === 1 ? '/sounds/ghostwriter_click1.mp3' : '/sounds/ghostwriter_click2.mp3'; 
   const audio = new Audio(audioSrc);
   audio.volume = 0.3;
   audio.play();


### PR DESCRIPTION
This commit addresses issues with the typewriter fade functionality:

1.  **Fade Timing**: Fades now correctly occur only after all preceding 'type', 'pause', and 'delete' actions in a sequence are fully completed.
2.  **Sequential Transformation Fades**: Each fade action transforms the text from its previous state to the new 'to_text'.
    *   `PaperDisplay.jsx` was updated to render character additions, deletions, and replacements with distinct fade-out and fade-in animations.
    *   New CSS animations (`transform-fade-in`, `transform-fade-out`) were added for these effects.
3.  **Disable Typing After Fades**: Once all fade actions in a sequence are concluded, further typing (both physical and virtual keyboard) is disabled.
4.  **`shouldGenerateTypeWriterResponse` Callback**:
    *   A snapshot of the text content (`currentText`, `latestAddition`, `latestPauseSeconds`, `lastGhostwriterWordCount`) is taken before the first fade action begins.
    *   The `shouldGenerateTypeWriterResponse` callback (passed as a prop) is invoked with this snapshot data after all fade actions are completed.

State management in `TypewriterFramework.jsx`'s `typingReducer` was updated to support these changes, including new states for `preFadeSnapshot` and `allFadesCompleted`.