### PR TITLE
Refactor: Handle new typewriter API response structure and add test

### DIFF
--- a/src/TypewriterFramework.jsx
+++ b/src/TypewriterFramework.jsx
@@ -1061,18 +1061,27 @@ const TypewriterFramework = (props) => {
       // (optional: you can disable this block if you never want inactivity autocompletion)
       fetchTypewriterReply(fullText, sessionId).then(response => {
         const reply = response.data; // Assuming response.data holds the sequence and metadata
-        if (reply && reply.writing_sequence) { // Check if writing_sequence exists
-            const hasFadeActions = reply.writing_sequence.some(action => action.action === 'fade');
+        let sequenceToDispatch = null;
+        let hasFadeActions = false;
+
+        if (reply && reply.writing_sequence && reply.fade_sequence) {
+          sequenceToDispatch = [...reply.writing_sequence, ...reply.fade_sequence];
+          hasFadeActions = reply.fade_sequence.some(action => action.action === 'fade') || reply.writing_sequence.some(action => action.action === 'fade');
+        } else if (reply && reply.writing_sequence) {
+          sequenceToDispatch = reply.writing_sequence;
+          hasFadeActions = reply.writing_sequence.some(action => action.action === 'fade');
+        }
+
+        if (sequenceToDispatch) {
             if (hasFadeActions) {
                 const currentTextForUser = pages[currentPage]?.text || '';
                 setUserTextBeforeGhostFade(currentTextForUser);
                 console.log('[Fade] Ghostwriter sequence with fades starting. Saving userTextBeforeGhostFade:', currentTextForUser);
             }
-            // The existing setCurrentFontStyles and dispatchTyping for START_NEW_SEQUENCE should follow.
             if (reply.metadata) { // Ensure metadata exists before trying to set it
               setCurrentFontStyles(reply.metadata);
             }
-            dispatchTyping({ type: typingActionTypes.START_NEW_SEQUENCE, payload: reply.writing_sequence });
+            dispatchTyping({ type: typingActionTypes.START_NEW_SEQUENCE, payload: sequenceToDispatch });
             dispatchGhostwriter({ type: ghostwriterActionTypes.SET_LAST_GENERATED_LENGTH, payload: fullText.length });
             dispatchGhostwriter({ type: ghostwriterActionTypes.SET_RESPONSE_QUEUED, payload: true });
         }
@@ -1104,18 +1113,27 @@ const TypewriterFramework = (props) => {
       if (shouldGenerate) {
         fetchTypewriterReply(fullText, sessionId).then(response => {
           const reply = response.data; // Assuming response.data holds the sequence and metadata
-          if (reply && reply.writing_sequence) { // Check if writing_sequence exists
-              const hasFadeActions = reply.writing_sequence.some(action => action.action === 'fade');
+          let sequenceToDispatch = null;
+          let hasFadeActions = false;
+
+          if (reply && reply.writing_sequence && reply.fade_sequence) {
+            sequenceToDispatch = [...reply.writing_sequence, ...reply.fade_sequence];
+            hasFadeActions = reply.fade_sequence.some(action => action.action === 'fade') || reply.writing_sequence.some(action => action.action === 'fade');
+          } else if (reply && reply.writing_sequence) {
+            sequenceToDispatch = reply.writing_sequence;
+            hasFadeActions = reply.writing_sequence.some(action => action.action === 'fade');
+          }
+
+          if (sequenceToDispatch) {
               if (hasFadeActions) {
                   const currentTextForUser = pages[currentPage]?.text || '';
                   setUserTextBeforeGhostFade(currentTextForUser);
                   console.log('[Fade] Ghostwriter sequence with fades starting. Saving userTextBeforeGhostFade:', currentTextForUser);
               }
-              // The existing setCurrentFontStyles and dispatchTyping for START_NEW_SEQUENCE should follow.
               if (reply.metadata) { // Ensure metadata exists before trying to set it
                 setCurrentFontStyles(reply.metadata);
               }
-              dispatchTyping({ type: typingActionTypes.START_NEW_SEQUENCE, payload: reply.writing_sequence });
+              dispatchTyping({ type: typingActionTypes.START_NEW_SEQUENCE, payload: sequenceToDispatch });
               dispatchGhostwriter({ type: ghostwriterActionTypes.SET_LAST_GENERATED_LENGTH, payload: fullText.length });
               dispatchGhostwriter({ type: ghostwriterActionTypes.SET_RESPONSE_QUEUED, payload: true });
               // lastGhostwriterWordCount will be set after sequence commits


### PR DESCRIPTION
I've modified TypewriterFramework.jsx to correctly process API responses containing separate 'writing_sequence' and 'fade_sequence' keys. The sequences are combined to ensure all actions are processed.

I've also added a new integration test to TypewriterFramework.integration.test.js specifically for this new API structure, verifying both writing and subsequent fade actions.

NOTE: I was prevented from fully validating TypewriterFramework.integration.test.js by a pre-existing parsing error ("Error: Expression expected") within the test file or its environment. This error impeded the execution of all tests in this file, including the newly added one. The implemented code changes are based on my logical interpretation of your requirements and component structure.